### PR TITLE
Added SNAPSHOT to version, added default goal

### DIFF
--- a/Project/pom.xml
+++ b/Project/pom.xml
@@ -4,13 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.radirius.mercury</groupId>
     <artifactId>Mercury</artifactId>
-    <version>1.0.1.11-dev</version>
+    <version>1.0.1.11-SNAPSHOT</version>
     <name>Mercury</name>
     <description>The Simple Java Game Library</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
+        <defaultGoal>clean install</defaultGoal>
         <sourceDirectory>src</sourceDirectory>
         <resources>
             <resource>


### PR DESCRIPTION
SNAPSHOT gets autoreplaced with the timestamp of the build in the maven repository

e.g before http://repo.blha303.biz/com/radirius/mercury/Mercury/1.0.1.11-dev/ (old jars get removed in favour of new ones, no build history) and after http://repo.blha303.biz/com/radirius/mercury/Mercury/1.0.1.11-SNAPSHOT/ (every jar is kept)